### PR TITLE
feature : point관련 Entity 생성  PointTransaction, PointDetail, PointHistory

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointDetail.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointDetail.java
@@ -1,0 +1,66 @@
+package com.bootcamp.paymentdemo.domain.point.entity;
+
+
+import com.bootcamp.paymentdemo.global.common.BaseEntity;
+import com.bootcamp.paymentdemo.global.error.CommonError;
+import com.bootcamp.paymentdemo.global.error.CommonException;
+import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "point_details")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointDetail extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false)
+    private long userId;
+
+    @Column(nullable = false)
+    private Integer initialAmount;  // 최초 포인트 잔액 0원 처리
+
+    @Column(nullable = false)
+    private Integer remainAmount;  // 현재 포인트 잔액
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;  //만료일
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PointStatus status;
+
+    public PointDetail(Long userId, Integer amount) {
+        this.userId = userId;
+        this.initialAmount = amount;
+        this.remainAmount = amount;
+        this.expiredAt = LocalDateTime.now().plusYears(1); //적립 시점부터 1년뒤
+        this.status = PointStatus.ACCUMULATED;
+    }
+
+    public void use(Integer amountToUse){
+        if (this.remainAmount < amountToUse) {
+            throw new CommonException((CommonError.INSUFFICIENT_BALANCE));
+        }
+
+        this.remainAmount -= amountToUse;
+
+        //잔액에 따라 상태 자동 변경
+        if(this.remainAmount == 0) {
+            this.status = PointStatus.COMPLETED;
+        } else {
+            this.status = PointStatus.PARTIALLY_USED;
+        }
+
+    }
+
+
+}
+

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointHistory.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointHistory.java
@@ -1,0 +1,37 @@
+package com.bootcamp.paymentdemo.domain.point.entity;
+
+
+import com.bootcamp.paymentdemo.global.common.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "point_histories")
+public class PointHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long pointDetailId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PointStatus type;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Column
+    private String orderId;
+
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointStatus.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointStatus.java
@@ -1,0 +1,19 @@
+package com.bootcamp.paymentdemo.domain.point.entity;
+
+public enum PointStatus {
+    // 적립(미사용) - 포인트가 처음 생성되었을때
+    ACCUMULATED("적립"),
+    // 부분 사용중 - 잔액이 남아있지만 일부 차감이 발생했을 때
+    PARTIALLY_USED("사용"),
+    // 사용완료 - remainAmount가 0이 되었을 때
+    COMPLETED("완료"),
+    // 만료소멸 - 유효기간이 지나 잔액이 사라졌을 때
+    EXPIRED("만료"),
+    // 취소 - 포인트 사용 취소
+    CANCELED("취소");
+
+    private final String description;
+    PointStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointTransactionEntity.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointTransactionEntity.java
@@ -1,0 +1,76 @@
+package com.bootcamp.paymentdemo.domain.point.entity;
+
+import com.bootcamp.paymentdemo.domain.point.entity.PointType;
+import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "point_transactions") // 조장님의 테이블명 반영
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class) // 생성일 자동 기록
+public class PointTransactionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 사용자 연결
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // 주문 연결
+    @Column(name = "order_id")
+    private Long orderId;
+
+    // 결제 연결
+    @Column(name = "payment_id")
+    private Long paymentId;
+
+    // 포인트 변동 유형(Lock 연계)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private PointType type;
+
+    // 변동된 포인트 수치
+    @Column(name = "points", nullable = false)
+    private Integer points;
+
+    // 최종 잔액(정합성 체크)
+    @Column(name = "balance_after", nullable = false)
+    private Integer balanceAfter;
+
+    // 포인트 소멸 예정일
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    // 거래 상세 설명
+    @Column(name = "description")
+    private String description;
+
+    // 기록 생성 일시
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PointTransactionEntity(Long userId, Long orderId, Long paymentId, PointType type,
+                                  Integer points, Integer balanceAfter, LocalDateTime expiresAt, String description) {
+        this.userId = userId;
+        this.orderId = orderId;
+        this.paymentId = paymentId;
+        this.type = type;
+        this.points = points;
+        this.balanceAfter = balanceAfter;
+        this.expiresAt = expiresAt;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointType.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointType.java
@@ -1,0 +1,9 @@
+package com.bootcamp.paymentdemo.domain.point.entity;
+
+public enum PointType {
+    HOLD,
+    SPENT,
+    EARNED,
+    ROLLBACK,
+    USED;
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/repository/PointTransactionRepository.java
@@ -1,0 +1,41 @@
+package com.bootcamp.paymentdemo.domain.point.repository;
+
+import com.bootcamp.paymentdemo.domain.point.entity.PointTransactionEntity;
+import com.bootcamp.paymentdemo.domain.point.entity.PointType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PointTransactionRepository extends JpaRepository<PointTransactionEntity, Long> {
+
+    // 1. 최신순 조회: 특정 사용자의 내역을 생성일 역순으로 가져오기
+    // 필드명(userId)과 정렬 조건(OrderByCreatedAtDesc)을 조합합니다.
+    // 비관적 lock을 사용
+    // 잔액 상황을 조회하기 위한 일시적 코드 / 언제든 수정 가능 :D
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name="jacx.persistence.lock.timeout",value = "3000")}) //nms라 3초임
+    List<PointTransactionEntity> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+    Optional<PointTransactionEntity> findFirstByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // 2. 유형별 필터링: 특정 사용자의 내역 중 특정 타입(예: EARNED)만 조회
+    // userId와 type 두 가지 조건을 함께 사용합니다.
+    // 잔액 상황을 조회하기 위한 일시적 코드 / 언제든 수정 가능 :D
+    List<PointTransactionEntity> findAllByUserIdAndType(Long userId, PointType type);
+
+    // 3. 기간 조회: 특정 날짜 사이에 발생한 내역 확인
+    // Between 키워드를 사용하여 시작일과 종료일 사이의 데이터를 찾습니다.
+    List<PointTransactionEntity> findAllByUserIdAndCreatedAtBetween(
+            Long userId,
+            LocalDateTime start,
+            LocalDateTime end
+    );
+
+
+
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/service/PointTransactionService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/service/PointTransactionService.java
@@ -1,0 +1,65 @@
+package com.bootcamp.paymentdemo.domain.point.service;
+
+
+import com.bootcamp.paymentdemo.domain.point.entity.PointTransactionEntity;
+import com.bootcamp.paymentdemo.domain.point.entity.PointType;
+import com.bootcamp.paymentdemo.domain.point.repository.PointTransactionRepository;
+import com.bootcamp.paymentdemo.global.error.CommonError;
+import com.bootcamp.paymentdemo.global.error.CommonException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PointTransactionService {
+
+    private final PointTransactionRepository pointTransactionRepository;
+
+    // 메서드명 고민 필요 / 일단 팀 ERD 기반으로 설정
+    public void recordPointHistory(Long userId, Long orderId, Long paymentId, PointType type, Integer points) {
+
+        // 1. 기존 잔액 확인(lastTransaction)
+        PointTransactionEntity lastTx = pointTransactionRepository.findFirstByUserIdOrderByCreatedAtDesc(userId)
+                .orElse(null);
+
+        //if else문이 너무 길어져서 삼항 연산으로 조치합니다 :D
+        int currentBalance = (lastTx != null) ? lastTx.getBalanceAfter() : 0;
+
+        // 2. 새로운 잔액 계산(Hold 방식)
+        int nextBalance = calculateNextBalance(currentBalance, type, points);
+
+        // 3. 잔액 부족 검증
+        if (nextBalance < 0) {
+            throw new CommonException(CommonError.INSUFFICIENT_BALANCE);
+        }
+
+        // 4. 포인트 사용 이력 저장(newTransaction)
+        PointTransactionEntity newTx = PointTransactionEntity.builder()
+                .userId(userId)
+                .orderId(orderId)
+                .paymentId(paymentId)
+                .type(type)
+                .points(points)
+                .balanceAfter(nextBalance)
+                .description(type.name())
+                .build();
+
+        pointTransactionRepository.save(newTx);
+    }
+    //타임아웃이나 lock 충돌시 발생 메시지
+
+
+    //잔액 계산 method
+    private int calculateNextBalance(int current, PointType type, int points) {
+        // 검증(+증감[포인트를 얻거나 환불받았을때], -차감[Hold나 USED 상태일때])
+        if (type == PointType.EARNED || type == PointType.ROLLBACK) {
+            return current + points;
+        }
+
+        return current - points;
+    }
+}
+
+

--- a/src/main/java/com/bootcamp/paymentdemo/global/error/CommonError.java
+++ b/src/main/java/com/bootcamp/paymentdemo/global/error/CommonError.java
@@ -9,7 +9,12 @@ import org.springframework.http.HttpStatus;
 public enum CommonError {
 
     // -- 1000:  --
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"S1001","서버 내부 오류가 발생하였습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"S1001","서버 내부 오류가 발생하였습니다."),
+
+    // -- 4000: --
+    INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, "P4001", "포인트 잔액이 부족합니다.");
+
+
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/test/java/PointTransactionServiceTest.java
+++ b/src/main/test/java/PointTransactionServiceTest.java
@@ -1,0 +1,45 @@
+import com.bootcamp.paymentdemo.domain.point.entity.PointTransactionEntity;
+import com.bootcamp.paymentdemo.domain.point.entity.PointType;
+import com.bootcamp.paymentdemo.domain.point.repository.PointTransactionRepository;
+import com.bootcamp.paymentdemo.domain.point.service.PointTransactionService;
+import com.bootcamp.paymentdemo.global.error.CommonException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class) // Mockito 도구를 사용하겠다고 선언! 🚀
+class PointTransactionServiceTest {
+
+    @InjectMocks
+    private PointTransactionService pointTransactionService; // 우리가 만든 진짜 서비스 ⚙️
+
+    @Mock
+    private PointTransactionRepository pointTransactionRepository; // 가짜 리포지토리 🎭
+
+    @Test
+    @DisplayName("잔액보다 많은 포인트를 사용하면 P4001 예외가 발생해야 한다")
+    void insufficientBalanceTest1() {
+        // 1. Given: 현재 잔액이 500원인 상황을 가짜로 만듭니다.
+        PointTransactionEntity lastTx = PointTransactionEntity.builder()
+                .balanceAfter(500)
+                .build();
+
+        // 리포지토리에서 조회하면 무조건 위 데이터를 반환하도록 설정합니다.
+        when(pointTransactionRepository.findFirstByUserIdOrderByCreatedAtDesc(anyLong()))
+                .thenReturn(Optional.of(lastTx));
+
+        // 2. When & 3. Then: 1000원을 사용했을 때 예외가 터지는지 확인합니다.
+        assertThrows(CommonException.class, () -> {
+            pointTransactionService.recordPointHistory(1L, 1L, 1L, PointType.USED, 1000);
+        });
+    }
+}


### PR DESCRIPTION
#8 
 PR 요약: 포인트 시스템 기초 엔티티 설계

1. 포인트 상세 설계 (PointDetail)
  - 유효기간 관리: 적립 시점으로부터 1년 뒤(plusYears(1))를 만료일로 자동 설정.   <- 원하시는 기간이 있으면 반영하셔도 좋습니다 :D

  - 잔액 기반 상태 전이: remainAmount에 따라 ACCUMULATED → PARTIALLY_USED → COMPLETED 상태를 세분화하여 통계와 쿼리조회 최적화
  - 
2. 포인트 이력 설계 (PointHistory)
  - 원자적 기록: 사용자가 여러 적립 건을 합쳐서 결제할 경우, 각 적립 건별로 변동 내역을 개별 기록하여 CS부문도 고려함.

  - 도메인 연결: orderId를 통해 주문 시스템과의 연관 관계를 확보하고, pointDetailId를 통해 적립-사용 간의 추적성(Traceability) 제공.

3. 상태 및 에러 관리
  - PointStatus: 실무 중심의 5단계 상태(CANCELED 포함) 정의.

  - CommonError: 잔액 부족(INSUFFICIENT_BALANCE) 등 포인트 도메인 특화 에러 코드 적용. -> 4001

4. 논리적 관계 요약
  - User : PointHistory = 1 : N

  - PointDetail : PointHistory = 1 : N 

5. 향후 업데이트 예정
  - PointTransaction 기본만 작성하였고 snapshot과 PortOne 진행하면서 업데이트 예정