### PR TITLE
feature : 포인트 결제 간 스냅샷 전략[비관적 lock] 구현

### DIFF
--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointDetail.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointDetail.java
@@ -19,10 +19,10 @@ public class PointDetail extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
 
     @Column(nullable = false)
-    private long userId;
+    private Long userId;
 
     @Column(nullable = false)
     private Integer initialAmount;  // 최초 포인트 잔액 0원 처리
@@ -45,6 +45,15 @@ public class PointDetail extends BaseEntity {
         this.status = PointStatus.ACCUMULATED;
     }
 
+    // 환불시 사용할 메서드임
+    public void cancelUsage(Integer amountToRestore) {
+        this.remainAmount += amountToRestore;
+        this.status = (this.remainAmount.equals(this.initialAmount))
+                ? PointStatus.ACCUMULATED : PointStatus.PARTIALLY_USED;
+    }
+
+
+    // 포인트 결제시
     public void use(Integer amountToUse){
         if (this.remainAmount < amountToUse) {
             throw new CommonException((CommonError.INSUFFICIENT_BALANCE));

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointHistory.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/entity/PointHistory.java
@@ -1,16 +1,17 @@
 package com.bootcamp.paymentdemo.domain.point.entity;
 
 
+import com.bootcamp.paymentdemo.domain.user.entity.UserEntity2;
 import com.bootcamp.paymentdemo.global.common.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.persistence.Entity;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 @Table(name = "point_histories")
 public class PointHistory extends BaseEntity {
 
@@ -18,20 +19,32 @@ public class PointHistory extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity2 user;
 
-    @Column(nullable = false)
-    private Long pointDetailId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "point_detail_id")
+    private PointDetail pointDetail;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private PointStatus type;
 
     @Column(nullable = false)
-    private Integer amount;
+    private Long amount;   // 정합성을 위해 long 사용
+
+    @Column(nullable = false)
+    private Long beforePoint;
+
+    @Column(nullable = false)
+    private Long afterPoint;
 
     @Column
     private String orderId;
+
+    @Column
+    private String reason;
+
 
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/repository/PointDetailRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/repository/PointDetailRepository.java
@@ -1,0 +1,12 @@
+package com.bootcamp.paymentdemo.domain.point.repository;
+
+import com.bootcamp.paymentdemo.domain.point.entity.PointDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PointDetailRepository extends JpaRepository<PointDetail, Long> {
+
+
+    List<PointDetail> findAllByUserIdAndRemainAmountGreaterThanOrderByExpiredAtAsc(Long userId, int i);
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/repository/PointHistoryRepository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/repository/PointHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.bootcamp.paymentdemo.domain.point.repository;
+
+import com.bootcamp.paymentdemo.domain.point.entity.PointHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/point/service/PointTransactionService.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/point/service/PointTransactionService.java
@@ -1,14 +1,19 @@
 package com.bootcamp.paymentdemo.domain.point.service;
 
 
-import com.bootcamp.paymentdemo.domain.point.entity.PointTransactionEntity;
-import com.bootcamp.paymentdemo.domain.point.entity.PointType;
+import com.bootcamp.paymentdemo.domain.point.entity.*;
+import com.bootcamp.paymentdemo.domain.point.repository.PointDetailRepository;
+import com.bootcamp.paymentdemo.domain.point.repository.PointHistoryRepository;
 import com.bootcamp.paymentdemo.domain.point.repository.PointTransactionRepository;
+import com.bootcamp.paymentdemo.domain.user.entity.UserEntity2;
+import com.bootcamp.paymentdemo.domain.user.repository.UserRepository2;
 import com.bootcamp.paymentdemo.global.error.CommonError;
 import com.bootcamp.paymentdemo.global.error.CommonException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class PointTransactionService {
 
     private final PointTransactionRepository pointTransactionRepository;
+    private final PointDetailRepository pointDetailRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+    private final UserRepository2 userRepository2;
 
     // 메서드명 고민 필요 / 일단 팀 ERD 기반으로 설정
     public void recordPointHistory(Long userId, Long orderId, Long paymentId, PointType type, Integer points) {
@@ -48,7 +56,6 @@ public class PointTransactionService {
 
         pointTransactionRepository.save(newTx);
     }
-    //타임아웃이나 lock 충돌시 발생 메시지
 
 
     //잔액 계산 method
@@ -60,6 +67,62 @@ public class PointTransactionService {
 
         return current - points;
     }
+
+    @Transactional // 데이터 변경이 일어나므로 쓰기 모드
+    public void usePoints(Long userId, Long totalAmountToUse, String orderId) {
+
+        // 1. [비관적 락] 유저 잔액(스냅샷)을 수정하기 위해 DB를 잠금
+        // 에러 작성 대기중
+        UserEntity2 user = (UserEntity2) userRepository2.findByIdWithLock(userId)
+                .orElseThrow(() -> new CommonException(CommonError.INSUFFICIENT_BALANCE));
+
+        // 2. [1차 검증] 전체 잔액이 부족하면 상세 내역을 뒤질 필요도 없이 즉시 리턴
+        if (user.getCurrentPoint() < totalAmountToUse) {
+            throw new CommonException(CommonError.INSUFFICIENT_BALANCE);
+        }
+
+        // 3. [상세 내역 조회] 만료일이 가장 빠른 순서대로, 잔액이 남은 것들만 가져옴
+        List<PointDetail> availableDetails = pointDetailRepository
+                .findAllByUserIdAndRemainAmountGreaterThanOrderByExpiredAtAsc(userId, 0);
+
+        long remainToDeduct = totalAmountToUse;
+
+        // 4. [순회 차감] 쪼개진 포인트 뭉치들을 하나씩 차감해나감.
+        for (PointDetail detail : availableDetails) {
+            if (remainToDeduct <= 0) break;
+
+            // 이번 뭉치에서 깎을 수 있는 최대 금액 계산
+            int detailRemain = detail.getRemainAmount();
+            long deductAmount = Math.min(detailRemain, remainToDeduct);
+
+            // [핵심] 유저 스냅샷 차감 + 이력(History) 객체 생성
+            // 우리가 만든 그 '통합 메서드'를 여기서 호출합니다!
+            PointHistory history = user.deductPointWithDetail(
+                    detail,
+                    deductAmount,
+                    orderId,
+                    PointStatus.COMPLETED,
+                    "과자 결제 사용"
+            );
+
+            // 5. 상세 내역(Detail)의 실제 잔액도 깎아줍니다. <- 공간 복잡도 올라감
+            detail.use((int) deductAmount);
+
+            // 6. 결과 저장
+            pointHistoryRepository.save(history);
+
+            // 남은 차감액 업데이트
+            remainToDeduct -= deductAmount;
+        }
+
+        // 반복문이 끝났는데도 remainToDeduct > 0 이라면 데이터 정합성에 문제가 있는거임.
+        if (remainToDeduct > 0) {
+            throw new IllegalStateException("포인트 계산 정합성 오류: 차감할 금액이 남았습니다.");
+        }
+    }
+
+
+
 }
 
 

--- a/src/main/java/com/bootcamp/paymentdemo/domain/user/entity/Entity.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/user/entity/Entity.java
@@ -1,4 +1,5 @@
 package com.bootcamp.paymentdemo.domain.user.entity;
 
+
 public class Entity {
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/user/entity/UserEntity2.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/user/entity/UserEntity2.java
@@ -1,0 +1,78 @@
+package com.bootcamp.paymentdemo.domain.user.entity;
+
+
+import com.bootcamp.paymentdemo.domain.point.entity.PointDetail;
+import com.bootcamp.paymentdemo.domain.point.entity.PointHistory;
+import com.bootcamp.paymentdemo.domain.point.entity.PointStatus;
+import com.bootcamp.paymentdemo.global.common.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "customers")
+public class UserEntity2 extends BaseEntity {
+
+    // 임호진이가 임시로 구현한 엔티티임 for SnapShot-------------
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String email;
+
+    // 포인트 잔액 스냅샷
+    @Column(nullable = false)
+    private Long currentPoint = 0L;
+
+    // 잔액 업데이트 메서드
+    public void deductPoint(Long amount) {
+        if(amount <= 0) {
+            throw new IllegalArgumentException("차감 금액은 0보다 커야 합니다.");
+        }
+
+        if(this.currentPoint < amount){
+            throw new IllegalStateException("잔액이 부족합니다. ( 현재: " + this.currentPoint + ")");
+        }
+        this.currentPoint -= amount;
+    }
+
+    public void addPoint(Long amount) {
+
+        if(amount <= 0) {
+            throw new IllegalArgumentException("적립 금액은 0보다 커야 합니다.");
+        }
+        this.currentPoint += amount;
+    }
+
+    // 스냅샷 메서드
+    public PointHistory deductPointWithDetail(PointDetail detail,
+                                              Long amountToDeduct,
+                                              String orderId,
+                                              PointStatus type,
+                                              String reason) {
+
+        // 1. 사전 검증
+        if (this.currentPoint < amountToDeduct) {
+            throw new IllegalStateException("잔액이 부족합니다.");
+        }
+
+        Long before = this.currentPoint;
+        this.currentPoint -= amountToDeduct; // 2. 스냅샷 차감
+        Long after = this.currentPoint;
+
+        // 3. PointHistory의 빌더를 호출
+        return PointHistory.builder()
+                .user(this)
+                .pointDetail(detail)
+                .amount(-amountToDeduct)
+                .beforePoint(before)
+                .afterPoint(after)
+                .type(type)
+                .orderId(orderId)
+                .reason(reason)
+                .build();
+    }
+}

--- a/src/main/java/com/bootcamp/paymentdemo/domain/user/repository/Repository.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/user/repository/Repository.java
@@ -1,4 +1,17 @@
 package com.bootcamp.paymentdemo.domain.user.repository;
 
-public interface Repository {
+import com.bootcamp.paymentdemo.domain.user.entity.UserEntity2;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface Repository extends JpaRepository<UserEntity2, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from UserEntity2 u where u.id= :id")
+    Optional<UserEntity2> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/bootcamp/paymentdemo/domain/user/repository/UserRepository2.java
+++ b/src/main/java/com/bootcamp/paymentdemo/domain/user/repository/UserRepository2.java
@@ -1,0 +1,10 @@
+package com.bootcamp.paymentdemo.domain.user.repository;
+
+import com.bootcamp.paymentdemo.domain.user.entity.UserEntity2;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository2 extends JpaRepository<UserEntity2, Long> {
+    Optional<Object> findByIdWithLock(Long userId);
+}


### PR DESCRIPTION
PR 요약: 포인트 시스템 스냅샷 및 비관적 락 도입

1. 개요 (Context)
포인트 조회 성능 향상과 데이터 무결성 보장을 위해 **사용자 잔액 스냅샷(User Snapshot)**과 비관적 락(Pessimistic Lock) 기반의 차감 로직을 구현.

2. 주요 변경 사항 (Key Changes)
  가. UserEntity2 잔액 스냅샷 추가: currentPoint 필드를 도입하여 결제/조회 시 매번 PointDetail을 합산하지 않고 즉시 잔액을 반환하도록 개선했습니다.
  * 임시로 구현한 엔티티여서 성현님이 pr올려주시면 2에 있는 코드를 옮기겠습니다 :D 

  나. 비관적 락(Pessimistic Lock) 적용: UserRepository에 @Lock(LockModeType.PESSIMISTIC_WRITE)을 적용하여 동시 결제 상황에서의 데이터 꼬임(Race Condition)을 원천 차단했습니다.
  * 임시로 구현한 레포여서 성현님이 pr올려주시면 2에 있는 코드를 옮기겠습니다 :D 
  
  다. Audit Trail(감사 로그) 강화: PointHistory에 beforePoint, afterPoint 필드를 추가하여 모든 포인트 변동의 전/후 상태를 추적 가능하게 설계했습니다.

  라. 포인트 차감 엔진 구현: 유효기간이 짧은 순서(OrderByExpiredAtAsc)로 상세 내역을 순회하며 차감하는 실무형 로직을 PointService에 반영했습니다.

3. 설계 결정 (Design Decisions)
  가. 계산 우선 원칙: 통계 쿼리의 편의성을 위해 사용 이력은 **음수(-)**로 기록하여 SUM(amount) 한 번으로 잔액 검증이 가능하게 했습니다.

  나. 최소 락 타임(Minimum Lock Time): 외부 API(PortOne 등) 호출 이후에 DB 락을 획득하도록 설계하여 시스템 가용성을 높였습니다.


4. 향후 업데이트 : user domain 완료 시 코드 병합 예정