### PR TITLE
fix: CD 배포 시 Dockerfile의 jar 빌드 파일명 인식 오류 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ FROM amazoncorretto:17-alpine
 
 WORKDIR /app
 
-# 1단계(build)에서 생성된 jar 파일만 쏙 뽑아서 현재 컨테이너로 복사
-# build/libs 폴더 밑에 생성된 *-SNAPSHOT.jar 파일을 app.jar라는 이름으로 가져옴
-COPY --from=build /app/build/libs/*-SNAPSHOT.jar app.jar
+# (수정 전) COPY --from=build /app/build/libs/*[!plain].jar app.jar
+# (수정 후) 1.0.0.jar 로 끝나는 진짜 실행 파일만 복사
+COPY --from=build /app/build/libs/*1.0.0.jar app.jar
 
 # 서버가 사용할 포트 번호 명시 (문서화 용도)
 EXPOSE 8080


### PR DESCRIPTION
## 작업 내역
- `Dockerfile` 내부의 jar 파일 복사(`COPY`) 명령어 정규식 수정
  - 수정 전: `COPY --from=build /app/build/libs/*-SNAPSHOT.jar app.jar`
  - 수정 후: `COPY --from=build /app/build/libs/*1.0.0.jar app.jar`

## 트러블슈팅 리포트: "왜 GitHub Actions는 성공했는데 서버는 죽었을까?"

**1. 발생했던 문제 (현상)**
- 어제부터 GitHub Actions 배포 파이프라인은 초록불(✅)이 뜨는데, 실제 EC2 서버에서는 스프링 부트가 켜지지 않고 502 에러가 발생하는 현상이 있었습니다.

**2. 원인 분석 (초록불의 비밀)**
- **스프링 부트 파일명 불일치:** 우리 프로젝트의 `build.gradle` 버전은 `1.0.0`으로 설정되어 있어 `paymentdemo-1.0.0.jar` 파일이 생성됩니다. 하지만 배포 스크립트(`Dockerfile`)는 `*-SNAPSHOT.jar`라는 이름의 파일을 찾도록 설정되어 있었습니다.
- **GitHub Actions의 함정:** GitHub Actions는 EC2 서버에 도커 컨테이너를 백그라운드(`-d` 옵션)로 실행시키는 명령까지만 내리고 "성공" 판정을 내립니다. 하지만 컨테이너 내부에서는 스프링 부트가 실행 파일을 찾지 못해 1초 만에 강제 종료(`Exited`)되어 버렸고, 깃허브는 이를 알 수 없었던 것이 진짜 원인이었습니다.

**3. 조치 사항**
- `Dockerfile`이 껍데기 파일(`-plain.jar`)을 제외한 **진짜 실행 파일(`*1.0.0.jar`)만 정확하게 인식하고 복사하도록 수정**했습니다.
- 포트를 점유하고 있던 찌꺼기 컨테이너들을 EC2 서버에서 직접 강제 삭제하여 초기화했습니다.

## 현재 상태
현재 `develop` 브랜치 기준으로 EC2 서버 자동 배포가 **정상적으로 가동 중(Up)**입니다! 프론트엔드 화면 접속 및 포트원 결제 테스트가 정상적으로 돌아가는지 한 번씩 확인 부탁드립니다.

## ✅ 체크리스트
- [x] Dockerfile 파일명 매칭 테스트 완료
- [x] EC2 서버 8080 포트 정상 기동 확인