### PR TITLE
chore: CD 파이프라인 JWT 시크릿 키 주입 및 문법 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
             echo "2. 최신 이미지 다운로드"
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/infra-skeleton:latest
             
-            echo "3. 도커 컨테이너 실행 (RDS 및 PortOne 환경변수 주입)"
+            echo "3. 도커 컨테이너 실행 (RDS, PortOne, JWT 환경변수 주입)"
             #  -e 옵션을 통해 깃허브 시크릿 값을 도커 컨테이너 내부로 전달합니다.
             sudo docker run -d --name infra-skeleton -p 8080:8080 \
               -e RDS_HOSTNAME="${{ secrets.RDS_HOSTNAME }}" \
@@ -55,6 +55,7 @@ jobs:
               -e PORTONE_STORE_ID="${{ secrets.PORTONE_STORE_ID }}" \
               -e PORTONE_CHANNEL_KG="${{ secrets.PORTONE_CHANNEL_KG }}" \
               -e PORTONE_CHANNEL_TOSS="${{ secrets.PORTONE_CHANNEL_TOSS }}" \
+              -e JWT_SECRET_KEY="${{ secrets.JWT_SECRET_KEY }}" \
               ${{ secrets.DOCKER_USERNAME }}/infra-skeleton:latest
             
             echo "4. 사용하지 않는 찌꺼기 이미지 삭제 (용량 확보)"


### PR DESCRIPTION
##  트러블슈팅: JWT 시크릿 키 에러 해결
- 문제: 배포 스크립트에 JWT 시크릿 키가 누락되어 있어, 스프링 부트가 기동 중 `jwt.secret-key`를 찾지 못해 컨테이너가 뻗어버리는 현상 발견
- 해결: 배포 서버(운영 환경) 전용으로 매우 복잡하고 긴 난수 문자열을 새로 발급하여 GitHub Secrets에 등록 후 주입 완료

## 팀원 안내 사항 (필독!)
1. 운영 서버 분리: 보안 규정상 로컬(내 컴퓨터) 환경과 운영(배포) 서버의 JWT 암호화 키는 다르게 가져가는 것이 정석입니다.
2. 로컬 테스트 방법: 운영 서버용 키는 제가 깃허브 비밀 금고에 꽂아 넣었으니, 백엔드 팀원분들은 원래 하시던 대로 `application-local.properties`에 있는 로컬용 키를 써서 개발하시면 됩니다.

## ✅ 체크리스트
- [x] deploy.yml 환경 변수 주입 문법 최종 확인
- [x] GitHub Secrets에 실제 운영용 값 등록 완료
- [x] EC2 서버 무중단 배포 및 정상 기동 확인 (도커 상태 `Up`)